### PR TITLE
Remote fetch working directory setting logic fixed

### DIFF
--- a/components/org.wso2.carbon.identity.remotefetch.common/src/main/java/org/wso2/carbon/identity/remotefetch/common/RemoteFetchConstants.java
+++ b/components/org.wso2.carbon.identity.remotefetch.common/src/main/java/org/wso2/carbon/identity/remotefetch/common/RemoteFetchConstants.java
@@ -50,6 +50,10 @@ public class RemoteFetchConstants {
     public static final String ID_UI_FIELD_BRANCH = "branch";
     public static final String ID_UI_FIELD_DIRECTORY = "directory";
 
+    // Config constants.
+    public static final String REMOTE_FETCH_ENABLED = "RemoteFetch.FetchEnabled";
+    public static final String REMOTE_FETCH_WORKING_DIRECTORY = "RemoteFetch.WorkingDirectory";
+
     /**
      * Grouping of constants related to database table names.
      */

--- a/components/org.wso2.carbon.identity.remotefetch.core/src/main/java/org/wso2/carbon/identity/remotefetch/core/util/RemoteFetchConfigurationUtils.java
+++ b/components/org.wso2.carbon.identity.remotefetch.core/src/main/java/org/wso2/carbon/identity/remotefetch/core/util/RemoteFetchConfigurationUtils.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.remotefetch.common.RemoteFetchCoreConfiguration;
 import org.wso2.carbon.identity.remotefetch.common.exceptions.RemoteFetchClientException;
 import org.wso2.carbon.identity.remotefetch.common.exceptions.RemoteFetchCoreException;
 import org.wso2.carbon.identity.remotefetch.common.exceptions.RemoteFetchServerException;
+import org.wso2.carbon.utils.CarbonUtils;
 
 import java.io.File;
 import java.util.Formatter;
@@ -42,6 +43,9 @@ public class RemoteFetchConfigurationUtils {
 
     private static final Log log = LogFactory.getLog(RemoteFetchConfigurationUtils.class);
 
+    public static final String REMOTE_FETCH_ENABLED = "RemoteFetch.FetchEnabled";
+    public static final String REMOTE_FETCH_WORKING_DIRECTORY = "RemoteFetch.WorkingDirectory";
+
     /**
      * Parse configuration from deployment toml file.
      *
@@ -52,15 +56,19 @@ public class RemoteFetchConfigurationUtils {
 
         boolean isEnabled = false;
         File workingDirectory = null;
-        String isEnabledProperty = IdentityUtil.getProperty("RemoteFetch.FetchEnabled");
-        String workingDirectoryProperty = IdentityUtil.getProperty("RemoteFetch.WorkingDirectory");
-        if (isEnabledProperty != null && !isEnabledProperty.isEmpty()) {
-            isEnabled = isEnabledProperty.equalsIgnoreCase("true");
-        }
-        if (workingDirectoryProperty != null && !workingDirectoryProperty.isEmpty()) {
+        String isEnabledProperty = IdentityUtil.getProperty(REMOTE_FETCH_ENABLED);
+        String workingDirectoryProperty = IdentityUtil.getProperty(REMOTE_FETCH_WORKING_DIRECTORY);
+
+        isEnabled = Boolean.parseBoolean(isEnabledProperty);
+        if (StringUtils.isNotBlank(workingDirectoryProperty)) {
             workingDirectory = new File(workingDirectoryProperty);
-            validateDirectory(workingDirectory);
+        } else {
+            // Set to default working directory at ${carbon.home}/tmp
+            String carbonHomeTmpDirPath = CarbonUtils.getCarbonHome() + File.separator + "tmp";
+            workingDirectory = new File(carbonHomeTmpDirPath);
         }
+        validateDirectory(workingDirectory);
+
         return new RemoteFetchCoreConfiguration(workingDirectory, isEnabled);
     }
 

--- a/components/org.wso2.carbon.identity.remotefetch.core/src/main/java/org/wso2/carbon/identity/remotefetch/core/util/RemoteFetchConfigurationUtils.java
+++ b/components/org.wso2.carbon.identity.remotefetch.core/src/main/java/org/wso2/carbon/identity/remotefetch/core/util/RemoteFetchConfigurationUtils.java
@@ -36,15 +36,15 @@ import java.util.Formatter;
 import java.util.List;
 import java.util.UUID;
 
+import static org.wso2.carbon.identity.remotefetch.common.RemoteFetchConstants.REMOTE_FETCH_ENABLED;
+import static org.wso2.carbon.identity.remotefetch.common.RemoteFetchConstants.REMOTE_FETCH_WORKING_DIRECTORY;
+
 /**
  * Parser for core configuration from deployment.toml file.
  */
 public class RemoteFetchConfigurationUtils {
 
     private static final Log log = LogFactory.getLog(RemoteFetchConfigurationUtils.class);
-
-    public static final String REMOTE_FETCH_ENABLED = "RemoteFetch.FetchEnabled";
-    public static final String REMOTE_FETCH_WORKING_DIRECTORY = "RemoteFetch.WorkingDirectory";
 
     /**
      * Parse configuration from deployment toml file.

--- a/components/org.wso2.carbon.identity.remotefetch.core/src/test/java/org/wso2/carbon/identity/remotefetch/core/util/RemoteFetchConfigurationUtilsTest.java
+++ b/components/org.wso2.carbon.identity.remotefetch.core/src/test/java/org/wso2/carbon/identity/remotefetch/core/util/RemoteFetchConfigurationUtilsTest.java
@@ -63,7 +63,7 @@ public class RemoteFetchConfigurationUtilsTest extends PowerMockTestCase {
     }
 
     @Test
-    public void testParseConfiguration() throws Exception {
+    public void testParseConfiguration() throws RemoteFetchCoreException {
 
         when(IdentityUtil.getProperty(RemoteFetchConfigurationUtils.REMOTE_FETCH_ENABLED)).thenReturn("true");
         when(IdentityUtil.getProperty(RemoteFetchConfigurationUtils.REMOTE_FETCH_WORKING_DIRECTORY)).thenReturn("tmp");

--- a/components/org.wso2.carbon.identity.remotefetch.core/src/test/java/org/wso2/carbon/identity/remotefetch/core/util/RemoteFetchConfigurationUtilsTest.java
+++ b/components/org.wso2.carbon.identity.remotefetch.core/src/test/java/org/wso2/carbon/identity/remotefetch/core/util/RemoteFetchConfigurationUtilsTest.java
@@ -38,6 +38,8 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+import static org.wso2.carbon.identity.remotefetch.common.RemoteFetchConstants.REMOTE_FETCH_ENABLED;
+import static org.wso2.carbon.identity.remotefetch.common.RemoteFetchConstants.REMOTE_FETCH_WORKING_DIRECTORY;
 
 /**
  * Unit test covering RemoteFetchConfigurationParser.
@@ -65,8 +67,8 @@ public class RemoteFetchConfigurationUtilsTest extends PowerMockTestCase {
     @Test
     public void testParseConfiguration() throws RemoteFetchCoreException {
 
-        when(IdentityUtil.getProperty(RemoteFetchConfigurationUtils.REMOTE_FETCH_ENABLED)).thenReturn("true");
-        when(IdentityUtil.getProperty(RemoteFetchConfigurationUtils.REMOTE_FETCH_WORKING_DIRECTORY)).thenReturn("tmp");
+        when(IdentityUtil.getProperty(REMOTE_FETCH_ENABLED)).thenReturn("true");
+        when(IdentityUtil.getProperty(REMOTE_FETCH_WORKING_DIRECTORY)).thenReturn("tmp");
 
         RemoteFetchCoreConfiguration remoteFetchCoreConfiguration = RemoteFetchConfigurationUtils.parseConfiguration();
         assertNotNull(remoteFetchCoreConfiguration);

--- a/components/org.wso2.carbon.identity.remotefetch.core/src/test/java/org/wso2/carbon/identity/remotefetch/core/util/RemoteFetchConfigurationUtilsTest.java
+++ b/components/org.wso2.carbon.identity.remotefetch.core/src/test/java/org/wso2/carbon/identity/remotefetch/core/util/RemoteFetchConfigurationUtilsTest.java
@@ -18,26 +18,43 @@
 
 package org.wso2.carbon.identity.remotefetch.core.util;
 
+import org.mockito.Mock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.IObjectFactory;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.remotefetch.common.RemoteFetchCoreConfiguration;
 import org.wso2.carbon.identity.remotefetch.common.exceptions.RemoteFetchCoreException;
+import org.wso2.carbon.utils.CarbonUtils;
+
+import java.io.File;
 
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 /**
  * Unit test covering RemoteFetchConfigurationParser.
  */
-@PrepareForTest(IdentityUtil.class)
+@PrepareForTest({IdentityUtil.class, CarbonUtils.class, RemoteFetchConfigurationUtils.class})
 public class RemoteFetchConfigurationUtilsTest extends PowerMockTestCase {
+
+    @Mock
+    private File mockedFile;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        mockStatic(IdentityUtil.class);
+        mockStatic(CarbonUtils.class);
+        whenNew(File.class).withAnyArguments().thenReturn(mockedFile);
+        when(mockedFile.isDirectory()).thenReturn(true);
+    }
 
     @ObjectFactory
     public IObjectFactory getObjectFactory() {
@@ -46,20 +63,23 @@ public class RemoteFetchConfigurationUtilsTest extends PowerMockTestCase {
     }
 
     @Test
-    public void testParseConfiguration() throws RemoteFetchCoreException {
+    public void testParseConfiguration() throws Exception {
 
-        mockStatic(IdentityUtil.class);
-        when(IdentityUtil.getProperty("RemoteFetch.FetchEnabled")).thenReturn("true");
-        RemoteFetchConfigurationUtils.parseConfiguration();
-        assertNotNull(RemoteFetchConfigurationUtils.parseConfiguration());
-        assertTrue(RemoteFetchConfigurationUtils.parseConfiguration().isEnableCore());
+        when(IdentityUtil.getProperty(RemoteFetchConfigurationUtils.REMOTE_FETCH_ENABLED)).thenReturn("true");
+        when(IdentityUtil.getProperty(RemoteFetchConfigurationUtils.REMOTE_FETCH_WORKING_DIRECTORY)).thenReturn("tmp");
+
+        RemoteFetchCoreConfiguration remoteFetchCoreConfiguration = RemoteFetchConfigurationUtils.parseConfiguration();
+        assertNotNull(remoteFetchCoreConfiguration);
+        assertTrue(remoteFetchCoreConfiguration.isEnableCore());
+        assertNotNull(remoteFetchCoreConfiguration.getWorkingDirectory());
     }
 
     @Test
     public void testParseConfigurationForNullValues() throws RemoteFetchCoreException {
 
-        assertNotNull(RemoteFetchConfigurationUtils.parseConfiguration());
-        assertFalse(RemoteFetchConfigurationUtils.parseConfiguration().isEnableCore());
-        assertNull(RemoteFetchConfigurationUtils.parseConfiguration().getWorkingDirectory());
+        RemoteFetchCoreConfiguration remoteFetchCoreConfiguration = RemoteFetchConfigurationUtils.parseConfiguration();
+        assertNotNull(remoteFetchCoreConfiguration);
+        assertFalse(remoteFetchCoreConfiguration.isEnableCore());
+        assertNotNull(remoteFetchCoreConfiguration.getWorkingDirectory());
     }
 }


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/product-is/issues/9675

## Approach
> The default value for the Remote Fetch working directory was given as `/tmp/`. This would only work with Unix filesystems, thereby, causing the server to throw errors in a Windows environment. Changing the default to `${carbon.home}/tmp` resolves this issue as the server obtains its root path correctly regardless of the environment.
