### PR TITLE
upgrade the velocity version to 2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -395,8 +395,8 @@
         <cedarsoftware.version>1.8.0</cedarsoftware.version>
 
         <!--velocity version-->
-        <velocity.version>1.7</velocity.version>
-        <org.wso2.orbit.org.apache.velocity.version>1.7.0.wso2v1</org.wso2.orbit.org.apache.velocity.version>
+        <velocity.version>2.3</velocity.version>
+        <org.wso2.orbit.org.apache.velocity.version>2.3.wso2v1</org.wso2.orbit.org.apache.velocity.version>
 
         <javaewah.version>1.1.6</javaewah.version>
         <!--<jcraft.jsch.version>0.1.54.wso2v1</jcraft.jsch.version>-->


### PR DESCRIPTION
## Purpose
The current version of velocity library is impacted by the log4j1 vulnerability.